### PR TITLE
Put the unmanaged dll's in an EmbeddedResource

### DIFF
--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -93,12 +93,12 @@
   <Target Name="AfterBuild">
   </Target>
   -->
-  <PropertyGroup Condition="$(OS) == 'Windows_NT'">
+  <!--<PropertyGroup Condition="$(OS) == 'Windows_NT'">
     <PostBuildEvent>xcopy /y /r "$(TargetDir)Dependencies\*.dll" "$(TargetDir)"</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS) != 'Windows_NT'">
     <PostBuildEvent>cp -r $(TargetDir)Dependencies/*.dll .</PostBuildEvent>
-  </PropertyGroup>
+  </PropertyGroup>-->
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>

--- a/libsodium-net/SodiumCore.cs
+++ b/libsodium-net/SodiumCore.cs
@@ -1,64 +1,85 @@
 ﻿using System;
 using System.Runtime.InteropServices;
-namespace Sodium
-{
-  /// <summary>
-  /// libsodium core information.
-  /// </summary>
-  public static class SodiumCore
-  {
-    private static bool _isInit;
+using System.IO;
+using System.Reflection;
+using System.Linq;
+using System.Text.RegularExpressions;
 
-    static SodiumCore()
-    {
-      Init();
-    }
+namespace Sodium {
+	/// <summary>
+	/// libsodium core information.
+	/// </summary>
+	public static class SodiumCore {
+		private static bool _isInit;
 
-    /// <summary>Gets random bytes</summary>
-    /// <param name="count">The count of bytes to return.</param>
-    /// <returns>An array of random bytes.</returns>
-    public static byte[] GetRandomBytes(int count)
-    {
-      var buffer = new byte[count];
-      SodiumLibrary.randombytes_buff(buffer, count);
+		static SodiumCore() {
+			Init();
+		}
 
-      return buffer;
-    }
+		/// <summary>Gets random bytes</summary>
+		/// <param name="count">The count of bytes to return.</param>
+		/// <returns>An array of random bytes.</returns>
+		public static byte[] GetRandomBytes(int count) {
+			var buffer = new byte[count];
+			SodiumLibrary.randombytes_buff(buffer, count);
 
-    /// <summary>
-    /// Gets a random number.
-    /// </summary>
-    /// <param name="upperBound">Integer between 0 and 2147483647.</param>
-    /// <returns>An unpredictable value between 0 and upperBound (excluded).</returns>
-    public static int GetRandomNumber(int upperBound)
-    {
-      var randomNumber = SodiumLibrary.randombytes_uniform(upperBound);
-    
-      return randomNumber;
-    }
+			return buffer;
+		}
 
-    /// <summary>
-    /// Returns the version of libsodium in use.
-    /// </summary>
-    /// <returns>
-    /// The sodium version string.
-    /// </returns>
-    public static string SodiumVersionString()
-    {
-      var ptr = SodiumLibrary.sodium_version_string();
+		/// <summary>
+		/// Gets a random number.
+		/// </summary>
+		/// <param name="upperBound">Integer between 0 and 2147483647.</param>
+		/// <returns>An unpredictable value between 0 and upperBound (excluded).</returns>
+		public static int GetRandomNumber(int upperBound) {
+			var randomNumber = SodiumLibrary.randombytes_uniform(upperBound);
 
-      return Marshal.PtrToStringAnsi(ptr);
-    }
+			return randomNumber;
+		}
 
-    /// <summary>Initialize libsodium.</summary>
-    /// <remarks>This only needs to be done once, so this prevents repeated calls.</remarks>
-    public static void Init()
-    {
-      if (!_isInit)
-      {
-        SodiumLibrary.init();
-        _isInit = true;
-      }
-    }
-  }
+		/// <summary>
+		/// Returns the version of libsodium in use.
+		/// </summary>
+		/// <returns>
+		/// The sodium version string.
+		/// </returns>
+		public static string SodiumVersionString() {
+			var ptr = SodiumLibrary.sodium_version_string();
+
+			return Marshal.PtrToStringAnsi(ptr);
+		}
+
+		public static void SaveUnmanagedDlls() {
+			var assembly = Assembly.GetExecutingAssembly();
+			var dir = Path.GetDirectoryName(new Uri(assembly.Location).LocalPath);
+			var resources = assembly.GetManifestResourceNames()
+				.Where(name => name.EndsWith(".dll", StringComparison.OrdinalIgnoreCase));
+			foreach (var res in resources) {
+				try {
+					var dllFile = Path.Combine(dir, Regex.Replace(res, @".*(?=\.[^.]+\.dll", "", RegexOptions.IgnoreCase));
+					using (var dest = new FileStream(dllFile, FileMode.Create, FileAccess.Write))
+					using (var src = assembly.GetManifestResourceStream(res)) {
+						src.CopyTo(dest);
+						dest.Close();
+					}
+				} catch { }
+			}
+		}
+
+		public static void InitLibrary() => SodiumLibrary.init();
+
+		/// <summary>Initialize libsodium.</summary>
+		/// <remarks>This only needs to be done once, so this prevents repeated calls.</remarks>
+		public static void Init() {
+			if (!_isInit) {
+
+
+				SaveUnmanagedDlls();
+
+				InitLibrary();
+
+				_isInit = true;
+			}
+		}
+	}
 }

--- a/libsodium-net/libsodium-net.csproj
+++ b/libsodium-net/libsodium-net.csproj
@@ -75,15 +75,9 @@
     <Compile Include="PasswordHash.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="Dependencies\libsodium.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Sodium.dll.config">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="Dependencies\libsodium-64.dll">
+    <EmbeddedResource Include="Dependencies\libsodium.dll" />
+    <EmbeddedResource Include="Dependencies\libsodium-64.dll" />
+    <Content Include="Sodium.dll.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
@@ -95,10 +89,10 @@
   <Target Name="AfterBuild">
   </Target>
   -->
-  <PropertyGroup Condition="$(OS) == 'Windows_NT'">
+  <!--<PropertyGroup Condition="$(OS) == 'Windows_NT'">
     <PostBuildEvent>xcopy /y /r "$(TargetDir)Dependencies\*.dll" "$(TargetDir)"</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS) != 'Windows_NT'">
     <PostBuildEvent>cp -r $(TargetDir)Dependencies/*.dll .</PostBuildEvent>
-  </PropertyGroup>
+  </PropertyGroup>-->
 </Project>


### PR DESCRIPTION
Put the unmanaged dll's in an EmbeddedResource and extract them to the dll's Location on startup, so the unmanaged dll's also work with shadow copying (e.g. ASP.NET).