### PR TITLE
Fix V3127

### DIFF
--- a/libsodium-net/PublicKeyBox.cs
+++ b/libsodium-net/PublicKeyBox.cs
@@ -131,7 +131,7 @@ namespace Sodium
 
       //validate the length of the public key
       if (publicKey == null || publicKey.Length != PublicKeyBytes)
-        throw new KeyOutOfRangeException("publicKey", (publicKey == null) ? 0 : secretKey.Length,
+        throw new KeyOutOfRangeException("publicKey", (publicKey == null) ? 0 : publicKey.Length,
           string.Format("key must be {0} bytes in length.", PublicKeyBytes));
 
       //validate the length of the nonce
@@ -168,7 +168,7 @@ namespace Sodium
 
       //validate the length of the public key
       if (publicKey == null || publicKey.Length != PublicKeyBytes)
-        throw new KeyOutOfRangeException("publicKey", (publicKey == null) ? 0 : secretKey.Length,
+        throw new KeyOutOfRangeException("publicKey", (publicKey == null) ? 0 : publicKey.Length,
           string.Format("key must be {0} bytes in length.", PublicKeyBytes));
 
       //validate the length of the nonce
@@ -261,7 +261,7 @@ namespace Sodium
 
       //validate the length of the public key
       if (publicKey == null || publicKey.Length != PublicKeyBytes)
-        throw new KeyOutOfRangeException("publicKey", (publicKey == null) ? 0 : secretKey.Length,
+        throw new KeyOutOfRangeException("publicKey", (publicKey == null) ? 0 : publicKey.Length,
           string.Format("key must be {0} bytes in length.", PublicKeyBytes));
 
       //validate the length of the mac


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio:

- Two similar code fragments were found. Perhaps, this is a typo and 'publicKey' variable should be used instead of 'secretKey' libsodium-net PublicKeyBox.cs 134

- Two similar code fragments were found. Perhaps, this is a typo and 'publicKey' variable should be used instead of 'secretKey' libsodium-net PublicKeyBox.cs 171

- Two similar code fragments were found. Perhaps, this is a typo and 'publicKey' variable should be used instead of 'secretKey' libsodium-net PublicKeyBox.cs 264