### PR TITLE
Implement support for XChaCha20-Poly1305

### DIFF
--- a/Tests/SecretAeadTest.cs
+++ b/Tests/SecretAeadTest.cs
@@ -9,8 +9,9 @@ namespace Tests
   {
     /// <summary>Test Authenticated Encryption with Additional Data</summary>
     /// <remarks>Binary source from: https://github.com/jedisct1/libsodium/blob/master/test/default/aead_chacha20poly1305.c</remarks>
-    [Test]
-    public void AeadWithAdditionalDataTest()
+    [TestCase(false)]
+    [TestCase(true)]
+    public void AeadWithAdditionalDataTest(bool useXChaCha)
     {
       var key = new byte[]
       {
@@ -34,8 +35,8 @@ namespace Tests
         0x86, 0xd0, 0x99, 0x74, 0x84, 0x0b, 0xde, 0xd2, 0xa5, 0xca
       };
 
-      var encrypted = SecretAead.Encrypt(m, nonce, key, ad);
-      var decrypted = SecretAead.Decrypt(encrypted, nonce, key, ad);
+      var encrypted = SecretAead.Encrypt(m, nonce, key, ad, useXChaCha);
+      var decrypted = SecretAead.Decrypt(encrypted, nonce, key, ad, useXChaCha);
 
       CollectionAssert.AreEqual(m, decrypted);
     }

--- a/libsodium-net/Interop/SodiumLibrary.cs
+++ b/libsodium-net/Interop/SodiumLibrary.cs
@@ -253,6 +253,19 @@ namespace Sodium.Interop
       long additionalDataLength, byte[] nonce, byte[] key);
 
     //crypto_aead_aes256gcm_is_available
+    //crypto_aead_chacha20poly1305_encrypt
+    [DllImport(Name, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int crypto_aead_xchacha20poly1305_ietf_encrypt(
+      IntPtr cipher, out long cipherLength, byte[] message, long messageLength, byte[] additionalData,
+      long additionalDataLength, byte[] nsec, byte[] nonce, byte[] key);
+
+    //crypto_aead_chacha20poly1305_decrypt
+    [DllImport(Name, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int crypto_aead_xchacha20poly1305_ietf_decrypt(
+      IntPtr message, out long messageLength, byte[] nsec, byte[] cipher, long cipherLength, byte[] additionalData,
+      long additionalDataLength, byte[] nonce, byte[] key);
+
+    //crypto_aead_aes256gcm_is_available
     [DllImport(Name, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_aead_aes256gcm_is_available();
 

--- a/libsodium-net/SecretAead.cs
+++ b/libsodium-net/SecretAead.cs
@@ -84,7 +84,7 @@ namespace Sodium
     /// <param name="cipher">The cipher to be decrypted.</param>
     /// <param name="nonce">The 8 byte nonce.</param>
     /// <param name="key">The 32 byte key.</param>
-    /// <param name="additionalData">The additional data. RFC 7539 says AAD can be any length.</param>
+    /// <param name="additionalData">The additional data.</param>
     /// <returns>The decrypted cipher.</returns>
     /// <exception cref="KeyOutOfRangeException"></exception>
     /// <exception cref="NonceOutOfRangeException"></exception>


### PR DESCRIPTION
Validation for the AAD length was also removed, per the [rfc](https://tools.ietf.org/html/rfc7539#section-2.8)

> AEAD_CHACHA20_POLY1305 is an authenticated encryption with additional
>   data algorithm.  The inputs to AEAD_CHACHA20_POLY1305 are:
>
>   o  A 256-bit key
>
>   o  A 96-bit nonce -- different for each invocation with the same key
>
>   o  An arbitrary length plaintext
>
>   o  Arbitrary length additional authenticated data (AAD)